### PR TITLE
Add dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "gulp-util": "^2.2.17",
     "gulp-watch": "~0.6.4"
   },
+  "dependencies": {
+    "angular": ">= 1.2",
+    "moment": ">= 2.6.0",
+    "moment-range": "~1.0.1"
+  },
   "keywords": [
     "angular",
     "date",


### PR DESCRIPTION
Allows the package to be installed directly with `npm install` / `yarn add`.